### PR TITLE
Add .editorconfig and fix indentation consistency / linting issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,16 @@
 version: 2
 jobs:
-    build:
-        docker:
-            - image: node:12.4.0-alpine
-        environment:
-            ENV: test
-        working_directory: ~/speedupamerica-frontend
-        steps:
-            - checkout
-            - run:
-                command: |
-                    npm ci
-                    npm run lint  
-                    npm run build   
-                    npm test
+  build:
+    docker:
+      - image: node:12.4.0-alpine
+    environment:
+      ENV: test
+    working_directory: ~/speedupamerica-frontend
+    steps:
+      - checkout
+      - run:
+        command: |
+          npm ci
+          npm run lint  
+          npm run build   
+          npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ jobs:
     steps:
       - checkout
       - run:
-        command: |
-          npm ci
-          npm run lint  
-          npm run build   
-          npm test
+          command: |
+            npm ci
+            npm run lint
+            npm run build
+            npm test

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# Get an EditorConfig plugin for your text editor:
+# https://editorconfig.org/#download
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_size = 4

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node ./dist/main.js",
     "start-dev": "nodemon -e ts,js,json -L --ignore dist/ --exec 'npm run build && npm start'",
-    "lint": "eslint *.json src/**/*.ts",
+    "lint": "eslint *.json src/**/*.ts test/**/*.ts",
     "build": "tsc -p .",
     "test": "mocha test/*.spec.ts"
   },

--- a/test/template.spec.ts
+++ b/test/template.spec.ts
@@ -1,13 +1,13 @@
 const assert = require('chai').assert;
 
-describe('Test Class Block', () =>  {
+describe('Test Class Block', () => {
   before(() => {
     // runs before all tests in this block
   });
 
   after(() => {
     // runs after all tests in this block
-  })
+  });
 
   beforeEach(() => {
     // runs before each test in this block

--- a/test/template.spec.ts
+++ b/test/template.spec.ts
@@ -1,27 +1,27 @@
 const assert = require('chai').assert;
 
 describe('Test Class Block', () =>  {
-    before(() => {
-        // runs before all tests in this block
+  before(() => {
+    // runs before all tests in this block
+  });
+
+  after(() => {
+    // runs after all tests in this block
+  })
+
+  beforeEach(() => {
+    // runs before each test in this block
+  });
+
+  afterEach(() => {
+    // runs after each test in this block
+  });
+
+  describe('Test 1 #get_all', () => {
+    it('Should get all', (done) => {
+      assert(true);
+
+      done();
     });
-
-    after(() => {
-        // runs after all tests in this block
-    })
-
-    beforeEach(() => {
-        // runs before each test in this block
-    });
-
-    afterEach(() => {
-        // runs after each test in this block
-    });
-
-    describe('Test 1 #get_all', () => {
-        it('Should get all', (done) => {
-            assert(true);
-
-            done();
-        });
-    });
+  });
 });


### PR DESCRIPTION
Notably:

* We now lint test files
* We now have 2-space indentation for everything except markdown. Adding the `.editorconfig` file can make this easier to maintain.