### PR TITLE
Add robots.txt and robots meta tag

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -20,6 +20,8 @@ app.enable('trust proxy');
 app.set('views', path.join(__dirname, '/views'));
 app.engine('handlebars', handlebars({defaultLayout: 'index'}));
 app.set('view engine', 'handlebars');
+// Give templates access to an {{isProduction}} boolean variable
+app.locals.isProduction = process.env.NODE_ENV === 'production';
 
 // Sass Setup
 app.use(sassMiddleware({
@@ -34,6 +36,7 @@ app.use(accessLogMiddleware());
 // Routes
 app.get('/health', healthController.health);
 app.get('/', homeController.index);
+app.get('/robots.txt', homeController.robots);
 app.use(express.static(path.join(__dirname, 'public')));
 
 // Test routes

--- a/src/application.ts
+++ b/src/application.ts
@@ -21,7 +21,7 @@ app.set('views', path.join(__dirname, '/views'));
 app.engine('handlebars', handlebars({defaultLayout: 'index'}));
 app.set('view engine', 'handlebars');
 // Give templates access to an {{isProduction}} boolean variable
-app.locals.isProduction = process.env.NODE_ENV === 'production';
+app.locals.isProduction = app.get('env') === 'production';
 
 // Sass Setup
 app.use(sassMiddleware({

--- a/src/controller/home.ts
+++ b/src/controller/home.ts
@@ -6,7 +6,7 @@ function index(_req:Request, res:Response) {
 }
 
 function robots(_req:Request, res:Response) {
-  res.status(HttpStatus.OK).render('robots', {layout: false});
+  res.status(HttpStatus.OK).type('text').render('robots', {layout: false});
 }
 
 export {index, robots};

--- a/src/controller/home.ts
+++ b/src/controller/home.ts
@@ -5,4 +5,8 @@ function index(_req:Request, res:Response) {
   res.status(HttpStatus.OK).render('home');
 }
 
-export {index};
+function robots(_req:Request, res:Response) {
+  res.status(HttpStatus.OK).render('robots', {layout: false});
+}
+
+export {index, robots};

--- a/src/views/layouts/index.handlebars
+++ b/src/views/layouts/index.handlebars
@@ -3,11 +3,14 @@
 
   <head>
     <meta charset="utf-8">
+    {{#unless isProduction}}
+    <meta name="robots" content="noindex, nofollow">
+    {{/unless}}
     <link rel="stylesheet" type="text/css" href="/stylesheets/style.css" media="screen" />
     <title>SpeedUpAmerica</title>
   </head>
 
-  <body> 
+  <body>
       {{>header}}
       {{{body}}}
   </body>

--- a/src/views/robots.handlebars
+++ b/src/views/robots.handlebars
@@ -1,0 +1,7 @@
+{{#if isProduction}}
+User-agent: *
+Allow: /
+{{else}}
+User-agent: *
+Disallow: /
+{{/if}}

--- a/test/controller/home.spec.ts
+++ b/test/controller/home.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import * as HttpStatus from 'http-status-codes';
 
 import {stubRequest, stubResponse} from '../helpers';
-import {index} from '../../src/controller/home';
+import {index, robots} from '../../src/controller/home';
 
 describe('Home Controller', () => {
   describe('index', () => {
@@ -16,6 +16,20 @@ describe('Home Controller', () => {
       expect(res.status.firstCall.args[0]).to.equal(HttpStatus.OK);
       expect(res.render.callCount).to.equal(1);
       expect(res.render.firstCall.args[0]).to.equal('home');
+    });
+  });
+
+  describe('robots', () => {
+    it('should return OK w/ body=home', () => {
+      const req = stubRequest();
+      const res = stubResponse();
+
+      robots(req, res);
+
+      expect(res.status.callCount).to.equal(1);
+      expect(res.status.firstCall.args[0]).to.equal(HttpStatus.OK);
+      expect(res.render.callCount).to.equal(1);
+      expect(res.render.firstCall.args[0]).to.equal('robots');
     });
   });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -9,10 +9,11 @@ function stubRequest(): any  {
 function stubResponse(): any {
   const res:any = {};
   res.status = sinon.stub().returns(res);
+  res.type = sinon.stub().returns(res);
   res.json = sinon.stub().returns(res);
   res.end = sinon.stub().returns(res);
   res.render = sinon.stub().returns(res);
-  
+
   return res as Response;
 };
 


### PR DESCRIPTION
Both `/robots.txt` and the rendering of the robots meta tag respond to the current environment settings so that web crawlers are disallowed in development but allowed in production.

I attempted to allow the app to detect changes to the environment on the fly (not just at startup), to make testing both behaviors easier, but I wasn't quite successful (I tried defining the `isProduction` attribute as a [getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#Custom_Setters_and_Getters), but the app always treated the value as falsy). The tests *do* verify the behavior of the template rendering, just not the app's setting of `isProduction`.

I manually verified that the startup detection works. You can test it yourself by changing `NODE_ENV` in the `local.env` file and restarting the container.

Closes #20 